### PR TITLE
Proposal 716

### DIFF
--- a/template/python27-flask/index.py
+++ b/template/python27-flask/index.py
@@ -8,7 +8,7 @@ app = Flask(__name__)
 
 @app.route("/", defaults={"path": ""}, methods=["POST", "GET"])
 @app.route("/<path:path>", methods=["POST", "GET"])
-def main_route():
+def main_route(path):
     ret = handler.handle(request.get_data())
     return ret
 

--- a/template/python27-flask/index.py
+++ b/template/python27-flask/index.py
@@ -6,7 +6,8 @@ from function import handler
 
 app = Flask(__name__)
 
-@app.route("/", methods=["POST", "GET"])
+@app.route("/", defaults={"path": ""}, methods=["POST", "GET"])
+@app.route("/<path:path>", methods=["POST", "GET"])
 def main_route():
     ret = handler.handle(request.get_data())
     return ret

--- a/template/python3-flask-armhf/index.py
+++ b/template/python3-flask-armhf/index.py
@@ -10,7 +10,7 @@ app = Flask(__name__)
 
 @app.route("/", defaults={"path": ""}, methods=["POST", "GET"])
 @app.route("/<path:path>", methods=["POST", "GET"])
-def main_route():
+def main_route(path):
     ret = handler.handle(request.get_data())
     return ret
 

--- a/template/python3-flask-armhf/index.py
+++ b/template/python3-flask-armhf/index.py
@@ -8,7 +8,8 @@ from gevent.pywsgi import WSGIServer
 
 app = Flask(__name__)
 
-@app.route("/", methods=["POST", "GET"])
+@app.route("/", defaults={"path": ""}, methods=["POST", "GET"])
+@app.route("/<path:path>", methods=["POST", "GET"])
 def main_route():
     ret = handler.handle(request.get_data())
     return ret

--- a/template/python3-flask/index.py
+++ b/template/python3-flask/index.py
@@ -10,7 +10,7 @@ app = Flask(__name__)
 
 @app.route("/", defaults={"path": ""}, methods=["POST", "GET"])
 @app.route("/<path:path>", methods=["POST", "GET"])
-def main_route():
+def main_route(path):
     ret = handler.handle(request.get_data())
     return ret
 

--- a/template/python3-flask/index.py
+++ b/template/python3-flask/index.py
@@ -8,7 +8,8 @@ from gevent.pywsgi import WSGIServer
 
 app = Flask(__name__)
 
-@app.route("/", methods=["POST", "GET"])
+@app.route("/", defaults={"path": ""}, methods=["POST", "GET"])
+@app.route("/<path:path>", methods=["POST", "GET"])
 def main_route():
     ret = handler.handle(request.get_data())
     return ret


### PR DESCRIPTION
Implement proposal 716, pass full paths to functions

This changes the default route to be catch-all, so that it
will match any path forwarded by the Gateway and watchdog.

Route-style as per Flask snippet 57:
http://flask.pocoo.org/snippets/57/

Tested by deploying example functions which echo back the path.

(NOTE: The Dockerfile reference to the `of-watchdog` binary will also need updated, but that is not a change I can make, since the `of-watchdog` binary is not available yet.  For testing I used a locally built `of-watchdog`.)

Signed-off-by: Thomas E Lackey <telackey@bozemanpass.com>