### PR TITLE
Additional Package, Watchdog args and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,10 @@ faas build \
 
 echo -n content | faas invoke myfunction
 ```
+
+## build-args
+
+This set of templates leverages two specific `build-arg`s for additional functionality:
+
+* `OF_WATCHDOG_VERSION` - string - semver2 version of of_watchdog as released on [GitHub](https://github.com/openfaas-incubator/of-watchdog/releases)
+* `ADDITIONAL_PACKAGES` - string - space separated set of Alpine Linux packages to install as underlying requirements for the application to run per [OpenFaaS Docs](https://docs.openfaas.com/cli/build/#20-pass-additional_package-through-build-arg)

--- a/template/python27-flask/Dockerfile
+++ b/template/python27-flask/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:2.7-alpine
 
+ARG ADDITIONAL_PACKAGE
+ARG OF_WATCHDOG_VERSION=0.2.5
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl \
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSLf https://github.com/openfaas-incubator/of-watchdog/releases/download/0.2.3/of-watchdog > /usr/bin/fwatchdog \
+    && curl -sSLf https://github.com/openfaas-incubator/of-watchdog/releases/download/$OF_WATCHDOG_VERSION/of-watchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 

--- a/template/python3-flask-armhf/Dockerfile
+++ b/template/python3-flask-armhf/Dockerfile
@@ -1,9 +1,11 @@
 FROM armhf/python:3.6-alpine
 
+ARG ADDITIONAL_PACKAGE
+ARG OF_WATCHDOG_VERSION=0.2.5
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl \
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSLf https://github.com/openfaas-incubator/of-watchdog/releases/download/0.2.4/of-watchdog-armhf > /usr/bin/fwatchdog \
+    && curl -sSLf https://github.com/openfaas-incubator/of-watchdog/releases/download/$OF_WATCHDOG_VERSION/of-watchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 

--- a/template/python3-flask/Dockerfile
+++ b/template/python3-flask/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.6-alpine
 
+ARG ADDITIONAL_PACKAGE
+ARG OF_WATCHDOG_VERSION=0.2.5
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl \
+RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSLf https://github.com/openfaas-incubator/of-watchdog/releases/download/0.2.3/of-watchdog > /usr/bin/fwatchdog \
+    && curl -sSLf https://github.com/openfaas-incubator/of-watchdog/releases/download/$OF_WATCHDOG_VERSION/of-watchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 


### PR DESCRIPTION
This is a very minor update that does 3 things: 

* Brings the `ADDITIONAL_PACKAGE` concept into this template per existing openfaas documentation 
* Moves the version of `of_watchdog` to a build argument with a default of the latest version (0.2.5 as of writing of this PR)
* Adds some brief documentation on these two arguments in the footer of the README