### PR TITLE
Include libffi to resolve wheel build errors

### DIFF
--- a/template/python3-flask/Dockerfile
+++ b/template/python3-flask/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache add curl \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 
-RUN apk --no-cache add musl-dev gcc make
+RUN apk --no-cache add musl-dev gcc make libffi-dev
 
 WORKDIR /root/
 


### PR DESCRIPTION
I see the library getting added in the ARM template (https://github.com/openfaas-incubator/python-flask-template/blob/master/template/python3-flask-armhf/Dockerfile#L10) but not here. Introducing this change resolves `pip` errors when requiring libraries which need libffi

```
Building wheels for collected packages: cffi, cryptography, itsdangerous, markupsafe, pycparser, pyyaml
  Running setup.py bdist_wheel for cffi: started
  Running setup.py bdist_wheel for cffi: finished with status 'error'
  Complete output from command /usr/local/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-225u_ud5/cffi/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-htapn97u --python-tag cp37:
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'libffi', required by 'virtual:world', not found
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'libffi', required by 'virtual:world', not found
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'libffi', required by 'virtual:world', not found
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'libffi', required by 'virtual:world', not found
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'libffi', required by 'virtual:world', not found
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.7
  creating build/lib.linux-x86_64-3.7/cffi
  copying cffi/verifier.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/vengine_gen.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/recompiler.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/ffiplatform.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/error.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/api.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/setuptools_ext.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/backend_ctypes.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/model.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/lock.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/cffi_opcode.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/__init__.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/commontypes.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/cparser.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/vengine_cpy.py -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/_cffi_include.h -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/parse_c_type.h -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/_embedding.h -> build/lib.linux-x86_64-3.7/cffi
  copying cffi/_cffi_errors.h -> build/lib.linux-x86_64-3.7/cffi
  running build_ext
  building '_cffi_backend' extension
  creating build/temp.linux-x86_64-3.7
  creating build/temp.linux-x86_64-3.7/c
  gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/local/include/python3.7m -c c/_cffi_backend.c -o build/temp.linux-x86_64-3.7/c/_cffi_backend.o
  c/_cffi_backend.c:15:17: fatal error: ffi.h: No such file or directory
   #include <ffi.h>
                   ^
  compilation terminated.
  error: command 'gcc' failed with exit status 1

  ----------------------------------------
  Failed building wheel for cffi
  Running setup.py clean for cffi
  Running setup.py bdist_wheel for cryptography: started
  Running setup.py bdist_wheel for cryptography: finished with status 'error'
  Complete output from command /usr/local/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-225u_ud5/cryptography/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-j27_6j2d --python-tag cp37:
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'libffi', required by 'virtual:world', not found
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'libffi', required by 'virtual:world', not found
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'libffi', required by 'virtual:world', not found
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'libffi', required by 'virtual:world', not found
  Package libffi was not found in the pkg-config search path.
  Perhaps you should add the directory containing `libffi.pc'
  to the PKG_CONFIG_PATH environment variable
  Package 'libffi', required by 'virtual:world', not found
  c/_cffi_backend.c:15:17: fatal error: ffi.h: No such file or directory
   #include <ffi.h>
                   ^
  compilation terminated.
  Traceback (most recent call last):
    File "/usr/local/lib/python3.7/distutils/unixccompiler.py", line 118, in _compile
      extra_postargs)
    File "/usr/local/lib/python3.7/distutils/ccompiler.py", line 909, in spawn
      spawn(cmd, dry_run=self.dry_run)
    File "/usr/local/lib/python3.7/distutils/spawn.py", line 36, in spawn
      _spawn_posix(cmd, search_path, dry_run=dry_run)
    File "/usr/local/lib/python3.7/distutils/spawn.py", line 159, in _spawn_posix
      % (cmd, exit_status))
  distutils.errors.DistutilsExecError: command 'gcc' failed with exit status 1
```