### PR TITLE
pass complete flask request to handler.py

### DIFF
--- a/template/python27-flask/function/handler.py
+++ b/template/python27-flask/function/handler.py
@@ -1,7 +1,7 @@
 def handle(req):
     """handle a request to the function
     Args:
-        req (str): request body
+        req (request): flask request
     """
 
     return req

--- a/template/python27-flask/index.py
+++ b/template/python27-flask/index.py
@@ -21,7 +21,7 @@ def fix_transfer_encoding():
 @app.route("/", defaults={"path": ""}, methods=["POST", "GET"])
 @app.route("/<path:path>", methods=["POST", "GET"])
 def main_route(path):
-    ret = handler.handle(request.get_data())
+    ret = handler.handle(request)
     return ret
 
 if __name__ == '__main__':

--- a/template/python3-flask-armhf/function/handler.py
+++ b/template/python3-flask-armhf/function/handler.py
@@ -1,7 +1,7 @@
 def handle(req):
     """handle a request to the function
     Args:
-        req (str): request body
+        req (request): flask request
     """
 
     return req

--- a/template/python3-flask-armhf/index.py
+++ b/template/python3-flask-armhf/index.py
@@ -23,7 +23,7 @@ def fix_transfer_encoding():
 @app.route("/", defaults={"path": ""}, methods=["POST", "GET"])
 @app.route("/<path:path>", methods=["POST", "GET"])
 def main_route(path):
-    ret = handler.handle(request.get_data())
+    ret = handler.handle(request)
     return ret
 
 if __name__ == '__main__':

--- a/template/python3-flask/function/handler.py
+++ b/template/python3-flask/function/handler.py
@@ -1,7 +1,7 @@
 def handle(req):
     """handle a request to the function
     Args:
-        req (str): request body
+        req (request): flask request
     """
 
     return req

--- a/template/python3-flask/index.py
+++ b/template/python3-flask/index.py
@@ -23,7 +23,7 @@ def fix_transfer_encoding():
 @app.route("/", defaults={"path": ""}, methods=["POST", "GET"])
 @app.route("/<path:path>", methods=["POST", "GET"])
 def main_route(path):
-    ret = handler.handle(request.get_data())
+    ret = handler.handle(request)
     return ret
 
 if __name__ == '__main__':


### PR DESCRIPTION
Passing the entire request to the handler opens a number of possibilities, among them support for multipart/form-data. Based on this change, I can create a function that accepts multiple pdf files as multipart/form-data and joins them into a single pdf:

```
from PyPDF2 import PdfFileMerger, PdfFileReader
from flask import send_file
import tempfile

def handle(req):
    """handle a request to the function
    Args:
        req (request): flask request
    """
    files = req.files
    file_storages = files.getlist("files")
    merger = PdfFileMerger()

    for file_storage in file_storages:
        pdfFileReader = PdfFileReader(file_storage)
        merger.append(pdfFileReader)

    fout = tempfile.TemporaryFile()
    merger.write(fout)

    for file_storage in file_storages:
        file_storage.close()

    fout.seek(0)
    return send_file(fout, 'application/pdf')
```