### PR TITLE
Non-root users for all templates

### DIFF
--- a/template/python27-flask/Dockerfile
+++ b/template/python27-flask/Dockerfile
@@ -8,20 +8,34 @@ ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add ${ADDITIONAL_PACKAGE}
 
-WORKDIR /root/
+# Add non root user
+RUN addgroup -S app && adduser app -S -G app
+RUN chown app /home/app
 
-COPY requirements.txt   .
-RUN pip install -r requirements.txt
+USER app
+
+ENV PATH=$PATH:/home/app/.local/bin
+
+WORKDIR /home/app/
+
 COPY index.py           .
+COPY requirements.txt   .
+USER root
+RUN pip install -r requirements.txt
+USER app
 
 RUN mkdir -p function
 RUN touch ./function/__init__.py
-WORKDIR /root/function/
+WORKDIR /home/app/function/
 COPY function/requirements.txt	.
-RUN pip install -r requirements.txt
+RUN pip install --user -r requirements.txt
 
-WORKDIR /root/
-COPY function           function
+WORKDIR /home/app/
+
+USER root
+COPY function   function
+RUN chown -R app:app ./
+USER app
 
 ENV fprocess="python index.py"
 ENV cgi_headers="true"

--- a/template/python3-flask-armhf/Dockerfile
+++ b/template/python3-flask-armhf/Dockerfile
@@ -9,20 +9,34 @@ RUN apk --no-cache add curl \
 
 RUN apk --no-cache add musl-dev gcc make openssl-dev libffi-dev
 
-WORKDIR /root/
+# Add non root user
+RUN addgroup -S app && adduser app -S -G app
+RUN chown app /home/app
 
-COPY requirements.txt   .
-RUN pip install -r requirements.txt
+USER app
+
+ENV PATH=$PATH:/home/app/.local/bin
+
+WORKDIR /home/app/
+
 COPY index.py           .
+COPY requirements.txt   .
+USER root
+RUN pip install -r requirements.txt
+USER app
 
 RUN mkdir -p function
 RUN touch ./function/__init__.py
-WORKDIR /root/function/
+WORKDIR /home/app/function/
 COPY function/requirements.txt	.
-RUN pip install -r requirements.txt
+RUN pip install --user -r requirements.txt
 
-WORKDIR /root/
-COPY function           function
+WORKDIR /home/app/
+
+USER root
+COPY function   function
+RUN chown -R app:app ./
+USER app
 
 ENV fprocess="python index.py"
 

--- a/template/python3-flask/Dockerfile
+++ b/template/python3-flask/Dockerfile
@@ -7,20 +7,34 @@ RUN chmod +x /usr/bin/fwatchdog
 ARG ADDITIONAL_PACKAGE
 RUN apk --no-cache add musl-dev gcc make ${ADDITIONAL_PACKAGE}
 
-WORKDIR /root/
+# Add non root user
+RUN addgroup -S app && adduser app -S -G app
+RUN chown app /home/app
 
-COPY requirements.txt   .
-RUN pip install -r requirements.txt
+USER app
+
+ENV PATH=$PATH:/home/app/.local/bin
+
+WORKDIR /home/app/
+
 COPY index.py           .
+COPY requirements.txt   .
+USER root
+RUN pip install -r requirements.txt
+USER app
 
 RUN mkdir -p function
 RUN touch ./function/__init__.py
-WORKDIR /root/function/
+WORKDIR /home/app/function/
 COPY function/requirements.txt	.
-RUN pip install -r requirements.txt
+RUN pip install --user -r requirements.txt
 
-WORKDIR /root/
-COPY function           function
+WORKDIR /home/app/
+
+USER root
+COPY function   function
+RUN chown -R app:app ./
+USER app
 
 ENV fprocess="python index.py"
 


### PR DESCRIPTION
Update all python-flask templates to use a non-root user

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

Tested by `exec`-ing into the containers and verifying the user and directory. Then, executing a `curl` command to ensure the function was still functioning (unable to test/verify the arm template as I do not at the moment have access to and arm device)

```
$ docker run -it python27-flask:test /bin/sh
~ $ ls
function          index.py          requirements.txt
~ $ pwd
/home/app
~ $ whoami
app

```

```
$ docker run -it python3-flask:test /bin/sh
~ $ ls
function          index.py          requirements.txt
~ $ pwd
/home/app
~ $ whoami
app

```