### PR TITLE
Update arm templates to use multi-arch watchdog

### DIFF
--- a/template/python27-flask/Dockerfile
+++ b/template/python27-flask/Dockerfile
@@ -8,20 +8,34 @@ ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add ${ADDITIONAL_PACKAGE}
 
-WORKDIR /root/
+# Add non root user
+RUN addgroup -S app && adduser app -S -G app
+RUN chown app /home/app
 
-COPY requirements.txt   .
-RUN pip install -r requirements.txt
+USER app
+
+ENV PATH=$PATH:/home/app/.local/bin
+
+WORKDIR /home/app/
+
 COPY index.py           .
+COPY requirements.txt   .
+USER root
+RUN pip install -r requirements.txt
+USER app
 
 RUN mkdir -p function
 RUN touch ./function/__init__.py
-WORKDIR /root/function/
+WORKDIR /home/app/function/
 COPY function/requirements.txt	.
-RUN pip install -r requirements.txt
+RUN pip install --user -r requirements.txt
 
-WORKDIR /root/
-COPY function           function
+WORKDIR /home/app/
+
+USER root
+COPY function   function
+RUN chown -R app:app ./
+USER app
 
 ENV fprocess="python index.py"
 ENV cgi_headers="true"

--- a/template/python3-flask-armhf/Dockerfile
+++ b/template/python3-flask-armhf/Dockerfile
@@ -9,20 +9,34 @@ RUN apk --no-cache add curl \
 
 RUN apk --no-cache add musl-dev gcc make openssl-dev libffi-dev
 
-WORKDIR /root/
+# Add non root user
+RUN addgroup -S app && adduser app -S -G app
+RUN chown app /home/app
 
-COPY requirements.txt   .
-RUN pip install -r requirements.txt
+USER app
+
+ENV PATH=$PATH:/home/app/.local/bin
+
+WORKDIR /home/app/
+
 COPY index.py           .
+COPY requirements.txt   .
+USER root
+RUN pip install -r requirements.txt
+USER app
 
 RUN mkdir -p function
 RUN touch ./function/__init__.py
-WORKDIR /root/function/
+WORKDIR /home/app/function/
 COPY function/requirements.txt	.
-RUN pip install -r requirements.txt
+RUN pip install --user -r requirements.txt
 
-WORKDIR /root/
-COPY function           function
+WORKDIR /home/app/
+
+USER root
+COPY function   function
+RUN chown -R app:app ./
+USER app
 
 ENV fprocess="python index.py"
 

--- a/template/python3-flask-armhf/Dockerfile
+++ b/template/python3-flask-armhf/Dockerfile
@@ -1,11 +1,10 @@
+FROM openfaas/of-watchdog:0.5.3 as watchdog
 FROM armhf/python:3.6-alpine
 
-# Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl \
-    && echo "Pulling watchdog binary from Github." \
-    && curl -sSLf https://github.com/openfaas-incubator/of-watchdog/releases/download/0.5.0/of-watchdog-armhf > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog \
-    && apk del curl --no-cache
+ARG ADDITIONAL_PACKAGE
+
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
 RUN apk --no-cache add musl-dev gcc make openssl-dev libffi-dev
 

--- a/template/python3-flask/Dockerfile
+++ b/template/python3-flask/Dockerfile
@@ -7,20 +7,34 @@ RUN chmod +x /usr/bin/fwatchdog
 ARG ADDITIONAL_PACKAGE
 RUN apk --no-cache add musl-dev gcc make ${ADDITIONAL_PACKAGE}
 
-WORKDIR /root/
+# Add non root user
+RUN addgroup -S app && adduser app -S -G app
+RUN chown app /home/app
 
-COPY requirements.txt   .
-RUN pip install -r requirements.txt
+USER app
+
+ENV PATH=$PATH:/home/app/.local/bin
+
+WORKDIR /home/app/
+
 COPY index.py           .
+COPY requirements.txt   .
+USER root
+RUN pip install -r requirements.txt
+USER app
 
 RUN mkdir -p function
 RUN touch ./function/__init__.py
-WORKDIR /root/function/
+WORKDIR /home/app/function/
 COPY function/requirements.txt	.
-RUN pip install -r requirements.txt
+RUN pip install --user -r requirements.txt
 
-WORKDIR /root/
-COPY function           function
+WORKDIR /home/app/
+
+USER root
+COPY function   function
+RUN chown -R app:app ./
+USER app
 
 ENV fprocess="python index.py"
 

--- a/template/python3-http-armhf/Dockerfile
+++ b/template/python3-http-armhf/Dockerfile
@@ -1,12 +1,10 @@
+FROM openfaas/of-watchdog:0.5.3 as watchdog
 FROM armhf/python:3.6-alpine
 
 ARG ADDITIONAL_PACKAGE
-# Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE} \
-    && echo "Pulling watchdog binary from Github." \
-    && curl -sSLf https://github.com/openfaas-incubator/of-watchdog/releases/download/0.4.6/of-watchdog-armhf > /usr/bin/fwatchdog \
-    && chmod +x /usr/bin/fwatchdog \
-    && apk del curl --no-cache
+
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
 
 # Add non root user
 RUN addgroup -S app && adduser app -S -G app


### PR DESCRIPTION
This is built up from PR #21 to include both non-roor users and arm multi-arch images