### PR TITLE
Set default value for HOSTNAME for python3-http templates

### DIFF
--- a/template/python3-http-armhf/index.py
+++ b/template/python3-http-armhf/index.py
@@ -17,7 +17,7 @@ class Event:
 
 class Context:
     def __init__(self):
-        self.hostname = os.environ['HOSTNAME']
+        self.hostname = os.getenv('HOSTNAME', 'localhost')
 
 def format_status_code(resp):
     if 'statusCode' in resp:

--- a/template/python3-http/index.py
+++ b/template/python3-http/index.py
@@ -17,7 +17,7 @@ class Event:
 
 class Context:
     def __init__(self):
-        self.hostname = os.environ['HOSTNAME']
+        self.hostname = os.getenv('HOSTNAME', 'localhost')
 
 def format_status_code(resp):
     if 'statusCode' in resp:


### PR DESCRIPTION
The `HOSTNAME` environment variable is not available in faasd, which makes any function using the `python3-http` template fail with the following error with a `KeyError` exception.

Setting a default value should fix this issue

Signed-off-by: Mehdi Yedes <mehdi.yedes@gmail.com>