### PR TITLE
Remove gevent and use waitress in all templates

### DIFF
--- a/template/python27-flask/Dockerfile
+++ b/template/python27-flask/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.2 as watchdog
+FROM openfaas/of-watchdog:0.7.7 as watchdog
 FROM python:2.7-alpine
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog

--- a/template/python3-flask-armhf/Dockerfile
+++ b/template/python3-flask-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.2 as watchdog
+FROM openfaas/of-watchdog:0.7.7 as watchdog
 FROM armhf/python:3.6-alpine
 
 ARG ADDITIONAL_PACKAGE
@@ -6,7 +6,7 @@ ARG ADDITIONAL_PACKAGE
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog
 
-RUN apk --no-cache add musl-dev gcc make openssl-dev libffi-dev
+RUN apk --no-cache add openssl-dev ${ADDITIONAL_PACKAGE}
 
 # Add non root user
 RUN addgroup -S app && adduser app -S -G app

--- a/template/python3-flask-armhf/index.py
+++ b/template/python3-flask-armhf/index.py
@@ -3,8 +3,7 @@
 
 from flask import Flask, request
 from function import handler
-#from gevent.wsgi import WSGIServer
-from gevent.pywsgi import WSGIServer
+from waitress import serve
 
 app = Flask(__name__)
 
@@ -27,7 +26,4 @@ def main_route(path):
     return ret
 
 if __name__ == '__main__':
-    #app.run(host='0.0.0.0', port=5000, debug=False)
-
-    http_server = WSGIServer(('', 5000), app)
-    http_server.serve_forever()
+    serve(app, host='0.0.0.0', port=5000)

--- a/template/python3-flask-armhf/requirements.txt
+++ b/template/python3-flask-armhf/requirements.txt
@@ -1,3 +1,3 @@
 flask
-gevent
+waitress
 

--- a/template/python3-flask-debian/Dockerfile
+++ b/template/python3-flask-debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.2 as watchdog
+FROM openfaas/of-watchdog:0.7.7 as watchdog
 FROM python:3.7-slim-buster
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog

--- a/template/python3-flask-debian/index.py
+++ b/template/python3-flask-debian/index.py
@@ -3,8 +3,7 @@
 
 from flask import Flask, request
 from function import handler
-#from gevent.wsgi import WSGIServer
-from gevent.pywsgi import WSGIServer
+from waitress import serve
 
 app = Flask(__name__)
 
@@ -27,6 +26,4 @@ def main_route(path):
     return ret
 
 if __name__ == '__main__':
-
-    http_server = WSGIServer(('0.0.0.0', 5000), app)
-    http_server.serve_forever()
+    serve(app, host='0.0.0.0', port=5000)

--- a/template/python3-flask-debian/requirements.txt
+++ b/template/python3-flask-debian/requirements.txt
@@ -1,3 +1,3 @@
 flask
-gevent
+waitress
 

--- a/template/python3-flask/Dockerfile
+++ b/template/python3-flask/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.2 as watchdog
+FROM openfaas/of-watchdog:0.7.7 as watchdog
 FROM python:3.7-alpine
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
@@ -7,7 +7,7 @@ RUN chmod +x /usr/bin/fwatchdog
 ARG ADDITIONAL_PACKAGE
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 
-RUN apk --no-cache add musl-dev gcc make ${ADDITIONAL_PACKAGE}
+RUN apk --no-cache add openssl-dev ${ADDITIONAL_PACKAGE}
 
 # Add non root user
 RUN addgroup -S app && adduser app -S -G app

--- a/template/python3-flask/index.py
+++ b/template/python3-flask/index.py
@@ -3,8 +3,7 @@
 
 from flask import Flask, request
 from function import handler
-#from gevent.wsgi import WSGIServer
-from gevent.pywsgi import WSGIServer
+from waitress import serve
 
 app = Flask(__name__)
 
@@ -27,7 +26,4 @@ def main_route(path):
     return ret
 
 if __name__ == '__main__':
-    #app.run(host='0.0.0.0', port=5000, debug=False)
-
-    http_server = WSGIServer(('', 5000), app)
-    http_server.serve_forever()
+    serve(app, host='0.0.0.0', port=5000)

--- a/template/python3-flask/requirements.txt
+++ b/template/python3-flask/requirements.txt
@@ -1,3 +1,3 @@
 flask
-gevent
+waitress
 

--- a/template/python3-http-armhf/Dockerfile
+++ b/template/python3-http-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.2 as watchdog
+FROM openfaas/of-watchdog:0.7.7 as watchdog
 FROM armhf/python:3.6-alpine
 
 ARG ADDITIONAL_PACKAGE

--- a/template/python3-http/Dockerfile
+++ b/template/python3-http/Dockerfile
@@ -1,4 +1,4 @@
-FROM openfaas/of-watchdog:0.7.2 as watchdog
+FROM openfaas/of-watchdog:0.7.7 as watchdog
 FROM python:3.7-alpine
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog


### PR DESCRIPTION
**What**
- Update all templates to use waitress instead of gevent.  This avoids
  the need to install things like gcc, make, or libffi-dev into the
  alpine images. The user can still install these via the
  ADDITIONAL_PACKAGES build arg, if they are needed.

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>