### PR TITLE
Enable binary responses in the http-templates

### DIFF
--- a/template/python3-http-debian/index.py
+++ b/template/python3-http-debian/index.py
@@ -17,41 +17,52 @@ class Event:
 
 class Context:
     def __init__(self):
-        self.hostname = os.environ['HOSTNAME']
+        self.hostname = os.getenv('HOSTNAME', 'localhost')
 
-def format_status_code(resp):
-    if 'statusCode' in resp:
-        return resp['statusCode']
+def format_status_code(res):
+    if 'statusCode' in res:
+        return res['statusCode']
     
     return 200
 
-def format_body(resp):
-    if 'body' not in resp:
-        return ""
-    elif type(resp['body']) == dict:
-        return jsonify(resp['body'])
-    else:
-        return str(resp['body'])
+def format_body(res, content_type):
+    if content_type == 'application/octet-stream':
+        return res['body']
 
-def format_headers(resp):
-    if 'headers' not in resp:
+    if 'body' not in res:
+        return ""
+    elif type(res['body']) == dict:
+        return jsonify(res['body'])
+    else:
+        return str(res['body'])
+
+def format_headers(res):
+    if 'headers' not in res:
         return []
-    elif type(resp['headers']) == dict:
+    elif type(res['headers']) == dict:
         headers = []
-        for key in resp['headers'].keys():
-            header_tuple = (key, resp['headers'][key])
+        for key in res['headers'].keys():
+            header_tuple = (key, res['headers'][key])
             headers.append(header_tuple)
         return headers
     
-    return resp['headers']
+    return res['headers']
 
-def format_response(resp):
-    if resp == None:
+def get_content_type(res):
+    content_type = ""
+    if 'headers' in res:
+        content_type = res['headers'].get('Content-type', '')
+    return content_type
+
+def format_response(res):
+    if res == None:
         return ('', 200)
 
-    statusCode = format_status_code(resp)
-    body = format_body(resp)
-    headers = format_headers(resp)
+    statusCode = format_status_code(res)
+    content_type = get_content_type(res)
+    body = format_body(res, content_type)
+
+    headers = format_headers(res)
 
     return (body, statusCode, headers)
 
@@ -60,10 +71,11 @@ def format_response(resp):
 def call_handler(path):
     event = Event()
     context = Context()
+
     response_data = handler.handle(event, context)
     
-    resp = format_response(response_data)
-    return resp
+    res = format_response(response_data)
+    return res
 
 if __name__ == '__main__':
     serve(app, host='0.0.0.0', port=5000)


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Enable binary responses in the http-templates

## Motivation and Context

This was not possible previously, and resulted in a byte array
being converted to a string and creating an invalid file.

To opt in, set the content type appropriately as:
application/octet-stream.

## How Has This Been Tested?

Before / after - one created a lot of serialised bytes and the after I got an image.

```python

from PIL import Image
import io

# Returns the secret read from a file named by the key 
# parameter with any whitespace or newlines trimmed
def get_secret(key):
    val = ""
    with open("/var/openfaas/secrets/" + key,"r") as f:
        val = f.read().strip()
    return val

def handle(event, context):
    secret = get_secret("bw-api-key")
    if event.headers.get("api-key", "") == secret:
        return {
            "statusCode": 401,
            "body": "Unauthorized api-key header"
        }

    buf = io.BytesIO()
    with Image.open(io.BytesIO(event.body)) as im:
        im_grayscale = im.convert("L")
        try:
            im_grayscale.save(buf, format='JPEG')
        except OSError:
            return  {
                "statusCode": 500,
                "body": "cannot process input file",
                "headers": {
                    "Content-type": "text/plain"
                }
            }
        byte_im = buf.getvalue()

        # Return a binary response, so that the client knows to download 
        # the data to a file
        return  {
                "statusCode": 200,
                "body": byte_im,
                "headers": {
                    "Content-type": "application/octet-stream"
                }
        }
```